### PR TITLE
Minor fixes for README and the base_resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Command Jobs is a terminal-based job finder and application tracker for software
 
 Use Command Jobs to streamline your job search and quickly find listings that are the best fit for your skills, experience and preferences
 
+## Update
+
+Thank you to the Hacker News community for the encouragement, enthusiasm and support. Check out this thread: [Show HN: Tech jobs on the command line](https://news.ycombinator.com/item?id=39621373)
+
 
 ## Features
 
@@ -42,7 +46,7 @@ After going through the Configuration and successfully running Command Jobs
 
 You will get a menu with the options below. To navigate the menu, just use the arrow keys and select options with Enter. You can quit at any time by pressing `q`
 
-When first running the app, open the Edit Resume section and paste the text of your resume, no need to include your name or contact info (you can see an example resume on `base_resume.sample`)
+When first running the app, open the Edit Resume section and paste the text of your resume, no need to include your name or contact info (you can see an example resume on `base_resume.sample`. Note: there's currently a minor bug when pasting a resume text, it's more reliable to paste the resume text directly into the `base_resume.txt` file, see issue #12)
 
 Then, get some job listings into the app by running Scrape "Ask HN: Who's hiring?". You can see the first few listings in the Navigate jobs in the local db section (if you want to see more, you can also open `job_listings.db` directly with sqlite3 and check out the contents)
 
@@ -105,7 +109,7 @@ To exit the application, press `q`
 
 4. Run the application:
 
-    `python3 src/main.py`
+    `python3 src/menu.py`
 
 
 

--- a/base_resume.sample
+++ b/base_resume.sample
@@ -11,13 +11,13 @@ CTO/Co-founder	AutopilotReviews	San Francisco / Los Angeles	10/2014 - Present
 ·	Drove the development of multiple backend integrations using Python and Selenium
 
 Founding Engineer	Padlet (YC W13)	San Francisco	09/2013 - 09/2014
-·	Instrumental in scaling the infrastructure of a Ruby on Rails/PostgreSQL + Angular + Node/Redis stack to support over 1 million registered users and 5,00
+·	Instrumental in scaling the infrastructure of a Ruby on Rails/PostgreSQL + Angular + Node/Redis stack to support over 1 million registered users and 5,000 concurrent connections
 ·	Played a key role in enhancing team capabilities through strategic recruitment and fostering a collaborative environment
 ·	Optimized Postgres performance for high-speed data processing and management, directly contributing to the platform's scalability and efficiency
 ·	Built and deployed in-house sensitive media detector, which was fundamental to Padlet’s capacity to grow
 
 CTO/Co-founder	ClickFono	Santiago, Chile	03/2008 - 08/2013
-·	Led the architectural design and server infrastructure setup, incorporating SIP/voice integrations with telecom providers to create the most advanced onl
+·	Led the architectural design and server infrastructure setup, incorporating SIP/voice integrations with telecom providers to create the most advanced online SaaS phone platform in Latin America at the time
 ·	Built a REST API for voice applications, using Ruby on Rails/PostgreSQL
 ·	Typical clients were top brands in Insurance, Banking, Finance, Retail, Telecommunications
 
@@ -33,11 +33,3 @@ PUC, Chile 2000-2006
 Double major CS and IEOR engineering degree
 
 Supervised Machine Learning, by Andrew Ng - Coursera 2017
-
-
-
-
-
-
-
-


### PR DESCRIPTION
As pointed out here: https://github.com/nicobrenner/commandjobs/issues/7#issuecomment-1982658468
there was an issue with the running instructions for python

There's also a bug (issue #12), which leaves out ends of longs lines in pasted text within the Edit Resume section