### PR TITLE
Remove unnecessary package pysqlite3 from requirements.txt fixes #17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 flask
-pysqlite3
 beautifulsoup4==4.9.3
 requests==2.25.1
 openai


### PR DESCRIPTION
Note: need to also fix the spacing in the python instructions

![image](https://github.com/nicobrenner/commandjobs/assets/2296756/4aa126ec-4f6d-4a83-87e1-1d9d6524c69e)

The two commands should be in separate lines