### PR TITLE
Add listings per ai request option

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ To exit the application, press `q`
         COMMANDJOBS_OUTPUT_FORMAT="{\n \"small_summary\": \"Wine and Open Source developers for C-language systems programming\",\n \"company_name\": \"CodeWeavers\",\n \"available_positions\": [\n {\n \"position\": \"Wine and General Open Source Developers\",\n \"link\": \"https://www.codeweavers.com/about/jobs\"\n }\n ],\n \"tech_stack_description\": \"C-language systems programming\",\n \"use_rails\": \"No\",\n \"use_python\": \"No\",\n \"remote_positions\": \"Yes\",\n \"hiring_in_us\": \"Yes\",\n \"how_to_apply\": \"Apply through our website, here is the link: https://www.codeweavers.com/about/jobs\",\n \"back_ground_with_priority\": null,\n \"fit_for_resume\": \"No\",\n \"fit_justification\": \"The position is for Wine and Open Source developers, neither of which the resume has experience with. The job is remote in the US\"\n }"
         ```
 
+3. Increase the limit of listings to check per batch
+
+    The option `COMMANDJOBS_LISTINGS_PER_BATCH` (which should be in your `.env` file, see `sample.env`) determines how many listings are processed each time the menu option "Find best matches with AI" is executed. If you are using the default of 10, it means that every time you run the option "Find best matches", Command Jobs will make 10 requests to `gpt`. Once you trust the app, I recommend setting the limit to 500, so that the app can process all scraped listings in one go
+
 ## Contributing
 
 We welcome contributions, especially in improving scrapers and enhancing user experience. If you'd like to help, please file an issue or pull request on [our GitHub repository](https://github.com/nicobrenner/commandjobs/issues).

--- a/sample.env
+++ b/sample.env
@@ -4,6 +4,8 @@ BASE_RESUME_PATH=/repo/base_resume.txt
 DB_PATH=/repo/job_listings.db
 HN_START_URL=https://news.ycombinator.com/item?id=39562986&p=1
 
+COMMANDJOBS_LISTINGS_PER_BATCH=10
+
 COMMANDJOBS_ROLE=backend engineer, or fullstack engineer, or senior engineer, or senior tech lead, or engineering manager, or senior enginering manager, or founding engineer, or founding fullstack engineer, or something similar
 
 COMMANDJOBS_IDEAL_JOB_QUESTIONS=and the company uses either Ruby, Rails, Ruby on Rails, or Python, the position doesn't require any knowledge or experience in any of the following: {job_requirement_exclusions}, the position is remote, it's for the US and the description matches the resume? (Yes or No), justify the Yes or No about the role being a good fit for the experience of the resume in one sentence.

--- a/src/display_matching_table.py
+++ b/src/display_matching_table.py
@@ -70,6 +70,7 @@ class MatchingTableDisplay:
                     AND json_extract(gi.answer, '$.fit_for_resume') = 'Yes'
                     AND json_extract(gi.answer, '$.remote_positions') = 'Yes'
                     AND json_extract(gi.answer, '$.hiring_in_us') <> 'No'
+                ORDER BY jl.id DESC
                 LIMIT 1 OFFSET {offset}
             """
             self.log(f"Executing query: {query}")  # Log the query
@@ -107,6 +108,7 @@ class MatchingTableDisplay:
                     AND json_extract(gi.answer, '$.fit_for_resume') = 'Yes'
                     AND json_extract(gi.answer, '$.remote_positions') = 'Yes'
                     AND json_extract(gi.answer, '$.hiring_in_us') <> 'No'
+                ORDER BY jl.id DESC
                 LIMIT {self.rows_per_page} OFFSET {offset}
             """
             self.log(f"Executing query: {query}")  # Log the query

--- a/src/gpt_processor.py
+++ b/src/gpt_processor.py
@@ -11,6 +11,7 @@ class GPTProcessor:
         self.db_manager = db_manager
         self.client = AsyncOpenAI(api_key=api_key)
         self.log_file = 'gpt_processor.log'  # Log file path
+        self.listings_per_request = os.getenv('COMMANDJOBS_LISTINGS_PER_BATCH')
 
     def log(self, message):
         """Append a message to the log file."""
@@ -20,7 +21,7 @@ class GPTProcessor:
     async def process_job_listings_with_gpt(self, resume_path, update_ui_callback):
         # Use update_ui_callback to communicate with the UI
         resume = self.read_resume_from_file(resume_path)
-        job_listings = self.db_manager.fetch_job_listings()
+        job_listings = self.db_manager.fetch_job_listings(self.listings_per_request)
         self.log(f"Creating tasks for {len(job_listings)} job listings")
         tasks = [self.process_single_listing(job_id, job_text, job_html, resume, update_ui_callback) for job_id, job_text, job_html in job_listings]
         self.log(f"About to 'gather' {len(tasks)} tasks")

--- a/src/menu.py
+++ b/src/menu.py
@@ -55,13 +55,15 @@ class MenuApp:
         self.table_display = MatchingTableDisplay(self.stdscr, self.db_path)
         self.total_ai_job_recommendations = self.table_display.fetch_total_entries()
         self.total_listings = self.get_total_listings()
+        env_limit = 0 if os.getenv('COMMANDJOBS_LISTINGS_PER_BATCH') is None else os.getenv('COMMANDJOBS_LISTINGS_PER_BATCH')
+        self.listings_per_request = max(int(env_limit), 10)
 
         resume_menu = "📄 Create resume (just paste it here once)"
-        find_best_matches_menu = "🧠 Create your resume"
+        find_best_matches_menu = "🧠 Find best matches with AI (Create your resume first)"
         resume_str = self.read_resume_from_file()
         if len(resume_str) > 0:
             resume_menu = "📄 Edit resume"
-            find_best_matches_menu = "🧠 Find best matches for resume with AI"
+            find_best_matches_menu = f"🧠 Find best matches for resume with AI (will check {self.listings_per_request} listings at a time)"
         
         db_menu_item = f"💾 Navigate jobs in local db ({self.total_listings} listings)"
         ai_recommendations_menu = "😅 No job matches for your resume yet"
@@ -185,6 +187,7 @@ class MenuApp:
         resume_str = self.read_resume_from_file()
         if len(resume_str) > 0:
             resume_menu = "📄 Edit resume"
+            find_best_matches_menu = f"🧠 Find best matches for resume with AI (will check {self.listings_per_request} listings at a time)"
         
         # Update menu items with the new counts
         db_menu_item = f"💾 Navigate jobs in local db ({self.total_listings} listings)"
@@ -193,9 +196,10 @@ class MenuApp:
             ai_recommendations_menu = f"✅ AI found {self.total_ai_job_recommendations} listings match your resume and job preferences"
         
         # Update the relevant menu items
-        self.menu_items[2] = db_menu_item
-        self.menu_items[4] = ai_recommendations_menu
         self.menu_items[0] = resume_menu
+        self.menu_items[2] = db_menu_item
+        self.menu_items[3] = find_best_matches_menu
+        self.menu_items[4] = ai_recommendations_menu
         
         # Redraw the menu to reflect the updated items
         self.draw_menu()


### PR DESCRIPTION
The option `COMMANDJOBS_LISTINGS_PER_BATCH` determines how many listings are processed each time the menu option "Find best matches with AI" is executed

The purpose of this option is to make testing the app faster, easier and less scarier in terms of gpt usage

Now the option to find AI matches includes a notice about how many listings will be checked (`🧠 Find best matches for resume with AI (will check 10 listings at a time)`)

![image](https://github.com/nicobrenner/commandjobs/assets/2296756/f38da11b-d154-483b-9cbc-181a5da4efcc)

The option can be is set, and can be changed, in the user's `.env` (an example was added to `sample.env`)