### PR TITLE
Change default values for BASE_RESUME and DB_PATH in config/sample.env

### DIFF
--- a/config/sample.env
+++ b/config/sample.env
@@ -1,7 +1,7 @@
 OPENAI_API_KEY=your_openai_api_key_here
 OPENAI_GPT_MODEL=gpt-3.5-turbo
-BASE_RESUME_PATH=/repo/base_resume.txt
-DB_PATH=/repo/job_listings.db
+BASE_RESUME_PATH=base_resume.txt
+DB_PATH=job_listings.db
 HN_START_URL=https://news.ycombinator.com/item?id=39562986&p=1
 
 COMMANDJOBS_LISTINGS_PER_BATCH=10


### PR DESCRIPTION
They had old/wrong values, preventing the application from starting on first run when using the `sample.env` as base for `.env`. This closes #41 