### PR TITLE
Add discard/apply controls and DB tracking for job matches

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
+set -e  # Exit immediately if any command fails
+
 echo "Starting the application..."
+
+echo ">>> Installing dependencies..."
 pip3 install -r config/requirements.txt || echo "Error, could not install requirements.txt $?"
+
+echo ">>> Running database migrations..."
+python3 src/migrations/001_add_discarded_applied.py || echo "Warning: migration script exited with error"
+
+echo ">>> Launching application..."
 exec python3 src/menu.py || echo "Python script exited with error code $?"
+
 echo "Application has terminated."

--- a/src/migrations/001_add_discarded_applied.py
+++ b/src/migrations/001_add_discarded_applied.py
@@ -1,0 +1,28 @@
+# migrations/001_add_discarded_applied.py
+
+import sqlite3
+
+DB_PATH = 'job_listings.db'   # <-- adjust if you use a different path
+
+def column_exists(cursor, table_name, column_name):
+    cursor.execute(f"PRAGMA table_info({table_name})")
+    return any(col[1] == column_name for col in cursor.fetchall())
+
+def main():
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+
+    if not column_exists(cursor, 'job_listings', 'discarded'):
+        print("Adding 'discarded' column...")
+        cursor.execute("ALTER TABLE job_listings ADD COLUMN discarded INTEGER DEFAULT 0")
+
+    if not column_exists(cursor, 'job_listings', 'applied'):
+        print("Adding 'applied' column...")
+        cursor.execute("ALTER TABLE job_listings ADD COLUMN applied INTEGER DEFAULT 0")
+
+    conn.commit()
+    conn.close()
+    print("Migration completed.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* Now when checking out the matches, the user can press `d` to Discard a match, or `a` to Apply to that job
* The listings are only marked as applied or discarded in the DB, they are not deleted
* This PR also adds basic migrations support and the first migration